### PR TITLE
Add GENOFLU processes

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -42,6 +42,14 @@ process {
         ]
     }
 
+    withName: 'MERGE_GENOFLU_RESULTS' {
+        publishDir = [
+            path: { "${params.outdir}/genoflu/" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
     withName: 'IVAR_VARIANTS' {
         publishDir = [
             path: { "${params.outdir}/variants" },

--- a/modules/local/consensus_merged/environment.yml
+++ b/modules/local/consensus_merged/environment.yml
@@ -1,0 +1,6 @@
+name: consensus_merged
+channels:
+  - conda-forge
+dependencies:
+  - bash=5.2.15
+  - coreutils=9.4

--- a/modules/local/consensus_merged/main.nf
+++ b/modules/local/consensus_merged/main.nf
@@ -1,0 +1,44 @@
+process CONSENSUS_MERGED {
+    tag "$meta.id"
+    label 'process_medium'
+
+    conda "${moduleDir}/environment.yml"
+
+    input:
+    tuple val(meta), val(genes), path(consensus_files)
+
+    output:
+    tuple val(meta), path("${meta.id}.fa"), emit: merged_fasta
+    path "versions.yml",                     emit: versions
+
+    script:
+    """
+    # Define segment order array
+    segments=("PB2" "PB1" "PA" "HA" "NP" "NA" "MP" "NS")
+
+    # Process each segment in order
+    for segment in "\${segments[@]}"; do
+        for consensus in ${consensus_files}; do
+            if [[ \$consensus == *"_\${segment}_cns.fa" ]]; then
+                cat \$consensus >> "${meta.id}.fa"
+                echo >> "${meta.id}.fa"
+            fi
+        done
+    done
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bash: \$(echo \$(bash --version 2>&1) | sed 's/^.*version //; s/ Release.*\$//')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch "${meta.id}.fa"
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bash: \$(echo \$(bash --version 2>&1) | sed 's/^.*version //; s/ Release.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/local/genoflu/environment.yml
+++ b/modules/local/genoflu/environment.yml
@@ -1,0 +1,9 @@
+name: genoflu
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.10
+  - genoflu
+  - blast
+  - openpyxl

--- a/modules/local/genoflu/main.nf
+++ b/modules/local/genoflu/main.nf
@@ -1,0 +1,43 @@
+process GENOFLU {
+    tag "$meta.id"
+    label 'process_medium'
+    
+    publishDir path: "${params.outdir}/genoflu", mode: 'copy', enabled: false, pattern: '*.tsv'
+
+    conda "${moduleDir}/environment.yml"
+
+    input:
+    tuple val(meta), path(merged_fasta)
+
+    output:
+    tuple val(meta), path("${meta.id}.tsv"), emit: genoflu_results
+    path "versions.yml",                      emit: versions
+
+    script:
+    """
+    if [ ! -s ${merged_fasta} ]; then
+        echo "Error: Input file ${merged_fasta} is empty or does not exist"
+        exit 1
+    fi
+
+    # Capture genoflu output and format it into TSV
+    genoflu.py -f ${merged_fasta} | grep "Genotype" | awk -F "--> " '{print "${meta.id}\t" \$2}' > ${meta.id}.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        genoflu: \$(genoflu.py --version 2>&1)
+        python: \$(python3 --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch ${meta.id}.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        genoflu: \$(genoflu.py --version 2>&1)
+        python: \$(python3 --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}

--- a/modules/local/merge_genoflu_results/main.nf
+++ b/modules/local/merge_genoflu_results/main.nf
@@ -1,0 +1,46 @@
+process MERGE_GENOFLU_RESULTS {
+    tag "merge_results"
+    label 'process_medium'
+    
+    publishDir path: "${params.outdir}/genoflu", mode: 'copy', pattern: 'genoflu_results.tsv', saveAs: { filename -> filename }
+
+    input:
+    path(tsv_files) 
+
+    output:
+    path "genoflu_results.tsv", emit: merged_results
+    path "versions.yml",        emit: versions
+
+    script:
+    """
+    if [ -z "${tsv_files}" ]; then
+        echo "Error: No TSV files provided to merge"
+        exit 1
+    fi
+
+    # Create header
+    echo -e "Sample\tGenotype" > genoflu_results.tsv
+    
+    # Combine all TSV files
+    for f in ${tsv_files}; do
+        cat \$f >> genoflu_results.tsv
+    done
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        genoflu: \$(genoflu.py --version 2>&1)
+        python: \$(python3 --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+
+    stub:
+    """
+    touch genoflu_results.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        genoflu: \$(genoflu.py --version 2>&1)
+        python: \$(python3 --version | sed 's/Python //g')
+    END_VERSIONS
+    """
+}


### PR DESCRIPTION
This PR adds three key components to improve flu genome analysis:

1. CONSENSUS_MERGED Process
- Merges consensus sequences from IVAR_CONSENSUS by SRR ID
- Orders gene segments according to standard order: PB2, PB1, PA, HA, NP, NA, MP, NS for genoflu

2. GENOFLU Process
- Processes merged consensus sequences using genoflu
- Generates genotype assignments for each sample

3. MERGE_GENOFLU_RESULTS Process
- Combines individual genoflu results into a single comprehensive TSV
- Adds appropriate headers for better data organization

Changes made:
- Added new modules in modules/local/
- Updated modules.config
- Modified workflow to incorporate new processes
- Added appropriate conda environment configurations